### PR TITLE
fix: Disabled mnemonic parsing on RecentDocumentsButton instances on …

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
@@ -154,7 +154,8 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
                 recentDocument.setAlignment(Pos.BASELINE_LEFT);
                 recentDocument.setOnAction(event -> fireOpenRecentProject(event, recentItem));
                 recentDocument.setTooltip(new Tooltip(recentItem));
-
+                /* if MnemonicParsing is enabled, file names with underscores are displayed incorrectly */
+                recentDocument.setMnemonicParsing(false);
                 recentDocumentButtons.add(recentDocument);
             }
 


### PR DESCRIPTION
…welcome page in oder to have correct file name rendering for filenames with underscores. (#578)

Co-authored-by: Oliver-Loeffler <Oliver-Loeffler@users.noreply.github.com>

<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)